### PR TITLE
Set up volumes for Yarn, Elm, and NPM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
 FROM ghcr.io/acilearning/docker-haskell:9.0.2
+
+# This commit is compatible with Elm version 0.19.1.
+# https://github.com/elm/compiler/compare/0.19.1...master
 ARG ELM_VERSION=c9aefb6230f5e0bda03205ab0499f6e4af924495
+
+# This comes from a fork of elm-format that adds support for Linux on ARM64.
+# https://github.com/avh4/elm-format/pull/777
 ARG ELM_FORMAT_VERSION=535866ba69b97eb1e5755191753baafa3a21ef5d
+
 RUN \
   set -o errexit -o xtrace; \
   sudo apt-get update; \
@@ -22,7 +29,7 @@ RUN \
   cp --verbose _build/elm-format ~/.local/bin; \
   elm-format --help
 
-FROM node:18.9.0
+FROM node:18.10.0
 RUN \
   set -o errexit -o xtrace; \
   apt-get update; \
@@ -34,5 +41,7 @@ COPY --from=0 /home/haskell/.local/bin/elm /usr/local/bin
 COPY --from=0 /home/haskell/.local/bin/elm-format /usr/local/bin
 RUN \
   set -o errexit -o xtrace; \
+  mkdir --parents --verbose ~/.cache ~/.elm ~/.npm; \
   elm --version; \
   elm-format --help
+VOLUME /home/node/.cache /home/node/.elm /home/node/.npm


### PR DESCRIPTION
I noticed that I was routinely having to create these directories. I figured the base image should pre-create them and mark them as volumes.

- `~/.cache`: Used by Yarn.
- `~/.elm`: Used by Elm.
- `~/.npm`: Used by NPM. 

---

- [x] I manually tested the code locally to make sure that it works.
- [x] If there is documentation, I made sure it's accurate and up to date.
- [x] If possible, I wrote automated tests for the new behavior.
